### PR TITLE
Remove `.html` from recognized file type

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -3,7 +3,6 @@
 'fileTypes': [
   'vue'
   'vue.html'
-  'html'
 ]
 'firstLineMatch': '<!(?i:DOCTYPE)|<(?i:html)|<\\?(?i:php)'
 'foldingStartMarker': '(?x)(<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?><!--(?!.*--\s*>)^<!--\ \#tminclude\ (?>.*?-->)$<\?(?:php)?.*\b(if|for(each)?|while)\b.+:\{\{?(if|foreach|capture|literal|foreach|php|section|strip)\{\s*($|\?>\s*$|//|/\*(.*\*/\s*$|(?!.*?\*/))))'


### PR DESCRIPTION
This ensures Atom doesn't recognize `.html` files as Vue components.
